### PR TITLE
Boss defeats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,12 +2,9 @@
 # This .gitignore file was automatically created by Microsoft(R) Visual Studio.
 ################################################################################
 
-/.vs/LiveSplit.HollowKnight/v14
+/.vs/
 /bin
 /Components/LiveSplit.HollowKnight.exe
 /obj
 /LiveSplit.HollowKnight.csproj.user
-/.vs/LiveSplit.HollowKnight/v15
 .idea
-/.vs/LiveSplit.HollowKnight/v16/Server/sqlite3
-/.vs/LiveSplit.HollowKnight/v16/.suo

--- a/Enums.cs
+++ b/Enums.cs
@@ -353,7 +353,9 @@
         killsOblobble,
         scenesGrubRescued,
         zoteStatueWallBroken,
-        ordealAchieved
+        ordealAchieved,
+        whiteDefenderDefeats,
+        greyPrinceDefeats
     }
     public enum GameState {
         INACTIVE,

--- a/HollowKnightComponent.cs
+++ b/HollowKnightComponent.cs
@@ -778,11 +778,17 @@ namespace LiveSplit.HollowKnight {
                     break;
                 case SplitName.WaterwaysEntry: shouldSplit = nextScene.StartsWith("Waterways_01") && nextScene != sceneName; break;
                 case SplitName.FogCanyonEntry: shouldSplit = nextScene.StartsWith("Fungus3_26") && nextScene != sceneName; break;
+                case SplitName.FungalWastesEntry:
+                    shouldSplit = (nextScene.StartsWith("Fungus2_06") // Room outside Leg Eater
+                        || nextScene.StartsWith("Fungus2_03") // From Queens' Station
+                        || nextScene.StartsWith("Fungus2_23") // Bretta from Waterways
+                        || nextScene.StartsWith("Fungus2_20") // Spore Shroom room, from QG (this one's unlikely to come up)
+                        ) && nextScene != sceneName; break;
                 case SplitName.SoulMasterEncountered: shouldSplit = mem.PlayerData<bool>(Offset.mageLordEncountered); break;
 
-                //case SplitName.CrystalMoundExit: shouldSplit = sceneName.StartsWith("Mines_35") && nextScene != sceneName; break;
-                case SplitName.CrystalPeakEntry: shouldSplit = nextScene.StartsWith("Mines_02") && nextScene != sceneName; break;
-                case SplitName.QueensGardensEntry: shouldSplit = nextScene.StartsWith("Fungus3_34") && nextScene != sceneName; break;
+                case SplitName.CrystalMoundExit: shouldSplit = sceneName.StartsWith("Mines_35") && nextScene != sceneName; break;
+                case SplitName.CrystalPeakEntry: shouldSplit = (nextScene.StartsWith("Mines_02") || nextScene.StartsWith("Mines_10")) && nextScene != sceneName; break;
+                case SplitName.QueensGardensEntry: shouldSplit = (nextScene.StartsWith("Fungus3_34") || nextScene.StartsWith("Deepnest_43")) && nextScene != sceneName; break;
                 case SplitName.BasinEntry: shouldSplit = nextScene.StartsWith("Abyss_04") && nextScene != sceneName; break;
                 case SplitName.HiveEntry: shouldSplit = nextScene.StartsWith("Hive_01") && nextScene != sceneName; break;
                 case SplitName.KingdomsEdgeEntry: shouldSplit = nextScene.StartsWith("Deepnest_East_03") && nextScene != sceneName; break;
@@ -891,6 +897,7 @@ namespace LiveSplit.HollowKnight {
                             );
                     }
                     break;
+                case SplitName.RidingStag: shouldSplit = mem.PlayerData<bool>(Offset.travelling); break;
                 case SplitName.WhitePalaceLowerEntry: shouldSplit = nextScene.StartsWith("White_Palace_01") && nextScene != sceneName; break;
                 case SplitName.WhitePalaceLowerOrb: shouldSplit = nextScene.StartsWith("White_Palace_02") && nextScene != sceneName; break;
                 case SplitName.QueensGardensPostArenaTransition: shouldSplit = nextScene.StartsWith("Fungus3_13") && nextScene != sceneName; break;
@@ -939,6 +946,7 @@ namespace LiveSplit.HollowKnight {
                 case SplitName.OnObtainSimpleKey: shouldSplit = store.CheckIncremented(Offset.simpleKeys); break;
                 case SplitName.OnUseSimpleKey: shouldSplit = store.CheckIncreasedBy(Offset.simpleKeys, -1); break;
                 case SplitName.OnObtainGrub: shouldSplit = store.CheckIncremented(Offset.grubsCollected); break;
+                case SplitName.OnObtainPaleOre: shouldSplit = store.CheckIncremented(Offset.ore); break;
                 case SplitName.OnDefeatGPZ: shouldSplit = store.CheckIncremented(Offset.greyPrinceDefeats); break;
                 case SplitName.OnDefeatWhiteDefender: shouldSplit = store.CheckIncremented(Offset.whiteDefenderDefeats); break;
 

--- a/HollowKnightComponent.cs
+++ b/HollowKnightComponent.cs
@@ -645,7 +645,7 @@ namespace LiveSplit.HollowKnight {
                 case SplitName.CollectorP: shouldSplit = sceneName.StartsWith("GG_Collector") && nextScene.StartsWith("GG_God_Tamer"); break;
                 case SplitName.GodTamerP: shouldSplit = sceneName.StartsWith("GG_God_Tamer") && nextScene.StartsWith("GG_Grimm"); break;
                 case SplitName.TroupeMasterGrimmP: shouldSplit = sceneName.StartsWith("GG_Grimm") && nextScene == "GG_Spa"; break;
-                case SplitName.GalienP: shouldSplit = sceneName.StartsWith("GG_Ghost_Galien") && (nextScene.StartsWith("GG_Grey_Prince_Zote") || nextScene.StartsWith("GG_Painter")); break;
+                case SplitName.GalienP: shouldSplit = sceneName.StartsWith("GG_Ghost_Galien") && (nextScene.StartsWith("GG_Grey_Prince_Zote") || nextScene.StartsWith("GG_Painter") || nextScene.StartsWith("GG_Uumuu")); break;
                 case SplitName.GreyPrinceZoteP: shouldSplit = sceneName.StartsWith("GG_Grey_Prince_Zote") && (nextScene.StartsWith("GG_Uumuu") || nextScene.StartsWith("GG_Failed_Champion")); break;
                 case SplitName.UumuuP: shouldSplit = sceneName.StartsWith("GG_Uumuu") && (nextScene.StartsWith("GG_Hornet_2") || nextScene.StartsWith("GG_Nosk_Hornet")); break;
                 case SplitName.Hornet2P: shouldSplit = sceneName.StartsWith("GG_Hornet_2") && (nextScene == "GG_Engine" || nextScene == "GG_Spa"); break;

--- a/HollowKnightComponent.cs
+++ b/HollowKnightComponent.cs
@@ -939,6 +939,9 @@ namespace LiveSplit.HollowKnight {
                 case SplitName.OnObtainSimpleKey: shouldSplit = store.CheckIncremented(Offset.simpleKeys); break;
                 case SplitName.OnUseSimpleKey: shouldSplit = store.CheckIncreasedBy(Offset.simpleKeys, -1); break;
                 case SplitName.OnObtainGrub: shouldSplit = store.CheckIncremented(Offset.grubsCollected); break;
+                case SplitName.OnDefeatGPZ: shouldSplit = store.CheckIncremented(Offset.greyPrinceDefeats); break;
+                case SplitName.OnDefeatWhiteDefender: shouldSplit = store.CheckIncremented(Offset.whiteDefenderDefeats); break;
+
                 case SplitName.FlowerRewardGiven: shouldSplit = mem.PlayerData<bool>(Offset.xunRewardGiven); break;
                 case SplitName.ColosseumBronzeUnlocked: shouldSplit = mem.PlayerData<bool>(Offset.colosseumBronzeOpened); break;
                 case SplitName.ColosseumSilverUnlocked: shouldSplit = mem.PlayerData<bool>(Offset.colosseumSilverOpened); break;

--- a/HollowKnightSettings.Designer.cs
+++ b/HollowKnightSettings.Designer.cs
@@ -128,6 +128,7 @@
             this.cboStartTriggerName.Name = "cboStartTriggerName";
             this.cboStartTriggerName.Size = new System.Drawing.Size(145, 21);
             this.cboStartTriggerName.TabIndex = 7;
+            this.cboStartTriggerName.SelectedIndexChanged += new System.EventHandler(this.cboStartTriggerName_SelectedIndexChanged);
             // 
             // chkAutosplitStartRuns
             // 

--- a/HollowKnightSettings.cs
+++ b/HollowKnightSettings.cs
@@ -201,7 +201,6 @@ namespace LiveSplit.HollowKnight {
                     MemberInfo info = typeof(SplitName).GetMember(AutosplitStartRuns.ToString())[0];
                     DescriptionAttribute description = (DescriptionAttribute)info.GetCustomAttributes(typeof(DescriptionAttribute), false)[0];
                     cboStartTriggerName.Text = description.Description;
-                    cboStartTriggerName.SelectedIndexChanged += new EventHandler(cboStartTriggerName_SelectedIndexChanged);
                 }
             }
             Ordered = isOrdered;

--- a/HollowKnightSettings.cs
+++ b/HollowKnightSettings.cs
@@ -260,6 +260,12 @@ namespace LiveSplit.HollowKnight {
                     }
                 }
             }
+
+            if (chkAutosplitStartRuns.Checked) {
+                string text = cboStartTriggerName.Text;
+                cboStartTriggerName.DataSource = GetAvailableSplits();
+                cboStartTriggerName.Text = text;
+            }
         }
         private void flowMain_DragDrop(object sender, DragEventArgs e) {
             UpdateSplits();

--- a/HollowKnightSplitSettings.cs
+++ b/HollowKnightSplitSettings.cs
@@ -588,7 +588,7 @@ namespace LiveSplit.HollowKnight {
         BasinEntry,
         [Description("Blue Lake (Transition)"), ToolTip("Splits on transition to Blue Lake from Gruz Mother scene (requires Ordered Splits)")]
         BlueLake,
-        [Description("Crystal Peak (Transition)"), ToolTip("Splits on transition to the room where the dive and toll entrances meet")]
+        [Description("Crystal Peak Entry (Transition)"), ToolTip("Splits on transition to the room where the dive and toll entrances meet, or the room right of Dirtmouth")]
         CrystalPeakEntry,
         [Description("Crystal Mound Exit (Transition)"), ToolTip("Splits on transition from Crystal Mound")]
         CrystalMoundExit,
@@ -596,7 +596,7 @@ namespace LiveSplit.HollowKnight {
         EnterAnyDream,
         [Description("Fog Canyon (Transition)"), ToolTip("Splits on transition to East Fog Canyon")]
         FogCanyonEntry,
-        [Description("Fungal Wastes (Transition)"), ToolTip("Splits on transition to Fungal Wastes")]
+        [Description("Fungal Wastes Entry (Transition)"), ToolTip("Splits on transition to Fungal Wastes (scene below Crossroads, right of QS, left of Waterways or with Spore Shroom")]
         FungalWastesEntry,
         [Description("Gorgeous Husk Killed (Transition)"), ToolTip("Splits on transition after Gorgeous Husk defeated")]
         TransGorgeousHusk,
@@ -620,7 +620,7 @@ namespace LiveSplit.HollowKnight {
         KingdomsEdgeOvercharmedEntry,
         [Description("NKG Dream (Transition)"), ToolTip("Splits on transition to NKG dream")]
         EnterNKG,
-        [Description("Queen's Garden - QGA/Mound Entry (Transition)"), ToolTip("Splits on transition to QG scene following QGA")]
+        [Description("Queen's Garden Entry (Transition)"), ToolTip("Splits on transition to QG scene following QGA or above Deepnest")]
         QueensGardensEntry,
         [Description("Queen's Garden - Frogs (Transition)"), ToolTip("Splits on transition to QG frogs scene")]
         QueensGardensFrogsTrans,

--- a/HollowKnightSplitSettings.cs
+++ b/HollowKnightSplitSettings.cs
@@ -250,7 +250,7 @@ namespace LiveSplit.HollowKnight {
         Marmu,
         [Description("Marmu (Essence)"), ToolTip("Splits when absorbing essence from Marmu")]
         MarmuEssence,
-        [Description("Mega Moss Charger (Boss)"), ToolTip("Splits when killing Mega Moss Charger")]
+        [Description("Massive Moss Charger (Boss)"), ToolTip("Splits when killing Massive Moss Charger")]
         MegaMossCharger,
         [Description("Nightmare King Grimm (Boss)"), ToolTip("Splits when killing Nightmare King Grimm")]
         NightmareKingGrimm,
@@ -590,12 +590,14 @@ namespace LiveSplit.HollowKnight {
         BlueLake,
         [Description("Crystal Peak (Transition)"), ToolTip("Splits on transition to the room where the dive and toll entrances meet")]
         CrystalPeakEntry,
-        //[Description("Crystal Mound Exit (Transition)"), ToolTip("Splits on transition from Crystal Mound")]
-        //CrystalMoundExit,
+        [Description("Crystal Mound Exit (Transition)"), ToolTip("Splits on transition from Crystal Mound")]
+        CrystalMoundExit,
         [Description("Enter Any Dream (Transition)"), ToolTip("Splits when entering any dream world")]
         EnterAnyDream,
-        [Description("Fog Canyon (Transition)"), ToolTip("Splits on transition to Fog Canyon")]
+        [Description("Fog Canyon (Transition)"), ToolTip("Splits on transition to East Fog Canyon")]
         FogCanyonEntry,
+        [Description("Fungal Wastes (Transition)"), ToolTip("Splits on transition to Fungal Wastes")]
+        FungalWastesEntry,
         [Description("Gorgeous Husk Killed (Transition)"), ToolTip("Splits on transition after Gorgeous Husk defeated")]
         TransGorgeousHusk,
         [Description("Greenpath (Transition)"), ToolTip("Splits when entering Greenpath")]
@@ -1166,6 +1168,8 @@ namespace LiveSplit.HollowKnight {
         OnUseSimpleKey,
         [Description("Grub (Obtain)"), ToolTip("Splits when obtaining a Grub")]
         OnObtainGrub,
+        [Description("Pale Ore (Obtain)"), ToolTip("Splits when obtaining a Pale Ore")]
+        OnObtainPaleOre,
         [Description("GPZ Overworld (Boss)"), ToolTip("Splits each time defeating Grey Prince Zote in Bretta's dream")]
         OnDefeatGPZ,
         [Description("WD Overworld (Boss)"), ToolTip("Splits each time defeating White Defender in Dung Defender's dream")]
@@ -1175,6 +1179,8 @@ namespace LiveSplit.HollowKnight {
         AnyTransition,
         [Description("Transition excluding Save State (Transition)"), ToolTip("Splits when the knight enters a transition (excludes save states and Sly's basement)")]
         TransitionAfterSaveState,
+        [Description("Riding Stag (Event)"), ToolTip("Splits while riding the stag")]
+        RidingStag,
         [Description("Manual Split (Misc)"), ToolTip("Never splits. Use this when you need to manually split while using ordered splits")]
         ManualSplit,
 

--- a/HollowKnightSplitSettings.cs
+++ b/HollowKnightSplitSettings.cs
@@ -1166,6 +1166,10 @@ namespace LiveSplit.HollowKnight {
         OnUseSimpleKey,
         [Description("Grub (Obtain)"), ToolTip("Splits when obtaining a Grub")]
         OnObtainGrub,
+        [Description("GPZ Overworld (Boss)"), ToolTip("Splits each time defeating Grey Prince Zote in Bretta's dream")]
+        OnDefeatGPZ,
+        [Description("WD Overworld (Boss)"), ToolTip("Splits each time defeating White Defender in Dung Defender's dream")]
+        OnDefeatWhiteDefender,
 
         [Description("Any Transition (Transition)"), ToolTip("Splits when the knight enters a transition (only one will split per transition)")]
         AnyTransition,


### PR DESCRIPTION
* Add splits for each time defeating GPZ and WD in the overworld
* Quick fix for Zoten't P3, though maybe it's worth investigating making the splits work regardless of next scene
* Mega Moss Charger -> Massive Moss Charger
* Crystal Mound exit
* Fungal Wastes entry transition
* Make CPeaks entry work from Dirtmouth, and QG entry work from Deepnest
* Riding Stag split
* Pale Ore obtain split
* Make StartTriggeringAutosplit box respect order
* Fix StartTriggeringAutosplit saving issue