### PR TITLE
Boss Entry Transitions, Geo Boss Transitions, Spell Twister Transitio…

### DIFF
--- a/HollowKnightComponent.cs
+++ b/HollowKnightComponent.cs
@@ -988,6 +988,22 @@ namespace LiveSplit.HollowKnight {
                 case SplitName.SoulTyrantEssenceWithSanctumGrub: shouldSplit = mem.PlayerData<bool>(Offset.mageLordOrbsCollected) && mem.PlayerDataStringList(Offset.scenesGrubRescued).Contains("Ruins1_32"); break;
                 case SplitName.EndingSplit: shouldSplit = nextScene.StartsWith("Cinematic_Ending", StringComparison.OrdinalIgnoreCase) || nextScene == "GG_End_Sequence"; break;
 
+                case SplitName.EnterHornet1: shouldSplit = nextScene.StartsWith("Fungus1_04") && nextScene != sceneName; break;
+                case SplitName.EnterSoulMaster: shouldSplit = nextScene.StartsWith("Ruins1_24") && nextScene != sceneName; break;
+                case SplitName.EnterHiveKnight: shouldSplit = nextScene.StartsWith("Hive_05") && nextScene != sceneName; break;
+                case SplitName.EnterHornet2: shouldSplit = nextScene.StartsWith("Deepnest_East_Hornet") && nextScene != sceneName; break;
+                case SplitName.EnterTMG:
+                    shouldSplit = nextScene.StartsWith("Grimm_Main_Tent") && nextScene != sceneName
+                    && mem.PlayerData<int>(Offset.grimmChildLevel) == 2
+                    && mem.PlayerData<int>(Offset.flamesCollected) == 3; break;
+
+                case SplitName.VengeflyKingTrans: shouldSplit = mem.PlayerData<bool>(Offset.zoteRescuedBuzzer) && nextScene != sceneName; break;
+                case SplitName.MegaMossChargerTrans: shouldSplit = mem.PlayerData<bool>(Offset.megaMossChargerDefeated) && nextScene != sceneName; break;
+
+                case SplitName.SpellTwisterTrans: shouldSplit = mem.PlayerData<bool>(Offset.gotCharm_33) && nextScene != sceneName; break;
+
+                case SplitName.GladeIdol: shouldSplit = store.CheckIncreased(Offset.trinket3) && sceneName.StartsWith("RestingGrounds_08"); break;
+
                 default:
                     //throw new Exception(split + " does not have a defined shouldsplit value");
                     if (!failedValues.Contains(split)) {

--- a/HollowKnightSplitSettings.cs
+++ b/HollowKnightSplitSettings.cs
@@ -595,7 +595,7 @@ namespace LiveSplit.HollowKnight {
 
         [Description("Ancient Basin (Transition)"), ToolTip("Splits on transition to Basin, alternative to the (Area) split")]
         BasinEntry,
-        [Description("Blue Lake (Transition)"), ToolTip("Splits on transition to Blue Lake from Gruz Mother scene (requires Ordered Splits)")]
+        [Description("Blue Lake (Transition)"), ToolTip("Splits on transition to Blue Lake (from either side)")]
         BlueLake,
         [Description("Crystal Peak Entry (Transition)"), ToolTip("Splits on transition to the room where the dive and toll entrances meet, or the room right of Dirtmouth")]
         CrystalPeakEntry,
@@ -1238,7 +1238,27 @@ namespace LiveSplit.HollowKnight {
         [Description("Manual Split (Misc)"), ToolTip("Never splits. Use this when you need to manually split while using ordered splits")]
         ManualSplit,
 
+        [Description("Enter Hornet 1 (Transition)"), ToolTip("Splits when entering Hornet 1 boss arena transition")]
+        EnterHornet1,
+        [Description("Enter Soul Master (Transition)"), ToolTip("Splits when entering Soul Master boss arena transition")]
+        EnterSoulMaster,
+        [Description("Enter Hornet 2 (Transition)"), ToolTip("Splits when entering Hornet 2 boss arena transition")]
+        EnterHornet2,
+        [Description("Enter Hive Knight (Transition)"), ToolTip("Splits when entering Hive Knight boss arena transition")]
+        EnterHiveKnight,
+        [Description("Enter Troupe Master Grimm (Transition)"), ToolTip("Splits when entering Grimm tent with requirements to trigger Troupe Master Grimm boss")]
+        EnterTMG,
 
+        [Description("Vengefly King Killed (Transition)"), ToolTip("Splits on transition after Vengefly King in Greenpath killed")]
+        VengeflyKingTrans,
+        [Description("Massive Moss Charger Killed (Transition)"), ToolTip("Splits on transition after Massive Moss Charger is killed")]
+        MegaMossChargerTrans,
+
+        [Description("Spell Twister (Transition)"), ToolTip("Splits on transition after picking up Spell Twister")]
+        SpellTwisterTrans,
+
+        [Description("Glade Idol (Relic)"), ToolTip("Splits when picking up the King's Idol in the Spirits' Glade")]
+        GladeIdol,
 
 
         /*


### PR DESCRIPTION
…n, and Glade Idol

basically just a few splits I wanted for myself in various categories, entry transitions for Hornet and Soul Master in all cats that apply, Hive Knight & TMG for 107 because the split before those bosses is in flux/has some inconsistency. Vengefly King and MMC transition splits are following from Gorgeous Husk transition split: geo collection is covered here and not spread out. Spell Twister transition split is because of early control from follies, and Glade Idol is because CPTE splitting on opening Glade and then having 30 more seconds before the City movement to Lemm felt awkward for me. Not major things in any case, dunno if others will even use any, but wanted to share them regardless. Oh also Blue Lake splits from either side so just fixed the tooltip for that.