### PR TITLE
"split this transition = true" at autostarting and other splits

### DIFF
--- a/Components/LiveSplit.HollowKnight.Updates.xml
+++ b/Components/LiveSplit.HollowKnight.Updates.xml
@@ -1,5 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <updates>
+    <update version="3.1.1">
+      <files>
+        <file path="Components/LiveSplit.HollowKnight.dll" status="changed"/>
+      </files>
+      <changelog>
+        <change>Leave Sly hut transition split with 106% items (lantern, shard, vfrag) bought. Fixes fake golds from shoptimising differently. (cerpin)</change>
+        <change>Renamed shopping splits from (event) to (transition) when appropriate. (cerpin)</change>
+        <change>Fixed auto-start on transition and auto-end on transition both happening on the same transition. (cerpin)</change>
+      </changelog>
+    </update>
     <update version="3.1.0">
         <files>
             <file path="Components/LiveSplit.HollowKnight.dll" status="changed"/>

--- a/HollowKnightComponent.cs
+++ b/HollowKnightComponent.cs
@@ -112,8 +112,6 @@ namespace LiveSplit.HollowKnight {
                     shouldSplit = (nextScene.Equals("Tutorial_01", StringComparison.OrdinalIgnoreCase) &&
                                    mem.GameState() == GameState.ENTERING_LEVEL) ||
                                   nextScene is "GG_Vengefly_V" or "GG_Boss_Door_Entrance" or "GG_Entrance_Cutscene";
-
-                    store.SplitThisTransition = true;
                 }
             } else if (Model.CurrentState.CurrentPhase == TimerPhase.Running && settings.Splits.Count > 0) {
                 GameState gameState = mem.GameState();
@@ -786,10 +784,15 @@ namespace LiveSplit.HollowKnight {
                 case SplitName.GreyPrinceEssence: shouldSplit = mem.PlayerData<bool>(Offset.greyPrinceOrbsCollected); break;
 
                 case SplitName.PreGrimmShop:
-                    shouldSplit = mem.PlayerData<bool>(Offset.hasLantern) &&
-                        mem.PlayerData<int>(Offset.maxHealthBase) == 6 &&
-                        (mem.PlayerData<int>(Offset.vesselFragments) == 4 ||
-                            (mem.PlayerData<int>(Offset.MPReserveMax) == 33 && mem.PlayerData<int>(Offset.vesselFragments) == 2));
+                    shouldSplit = mem.PlayerData<bool>(Offset.hasLantern)
+                        && mem.PlayerData<int>(Offset.maxHealthBase) == 6 
+                        && (mem.PlayerData<int>(Offset.vesselFragments) == 4 || (mem.PlayerData<int>(Offset.MPReserveMax) == 33 && mem.PlayerData<int>(Offset.vesselFragments) == 2));
+                    break;
+                case SplitName.PreGrimmShopTrans:
+                    shouldSplit = mem.PlayerData<bool>(Offset.hasLantern) 
+                        && mem.PlayerData<int>(Offset.maxHealthBase) == 6 
+                        && (mem.PlayerData<int>(Offset.vesselFragments) == 4 || (mem.PlayerData<int>(Offset.MPReserveMax) == 33 && mem.PlayerData<int>(Offset.vesselFragments) == 2))
+                        && !sceneName.StartsWith("Room_shop");
                     break;
                 case SplitName.ElderHuEssence: shouldSplit = mem.PlayerData<int>(Offset.elderHuDefeated) == 2; break;
                 case SplitName.GalienEssence: shouldSplit = mem.PlayerData<int>(Offset.galienDefeated) == 2; break;
@@ -995,10 +998,6 @@ namespace LiveSplit.HollowKnight {
                     break;
             }
 
-            if (shouldSplit) {
-                store.SplitThisTransition = true;
-                store.Update();
-            }
             return shouldSplit;
         }
         private void HandleSplit(bool shouldSplit, bool shouldReset = false) {
@@ -1012,6 +1011,8 @@ namespace LiveSplit.HollowKnight {
                 } else {
                     Model.Split();
                 }
+                store.SplitThisTransition = true;
+                store.Update();
             }
         }
 #endif

--- a/HollowKnightSplitSettings.cs
+++ b/HollowKnightSplitSettings.cs
@@ -407,7 +407,9 @@ namespace LiveSplit.HollowKnight {
 
         [Description("106% Pre-Grimm Shop (Event)"), ToolTip("Splits when Lantern + Vessel Fragment(5) + Mask Shard(4) have been acquired")]
         PreGrimmShop,
-        [Description("1xx% Sly Final Shop (Event)"), ToolTip("Splits on leaving Sly's shop after having bough Sprintmaster and Vessel Frag 8")]
+        [Description("106% Pre-Grimm Shop (Transition)"), ToolTip("Splits when Lantern + Vessel Fragment(5) + Mask Shard(4) have been acquired")]
+        PreGrimmShopTrans,
+        [Description("1xx% Sly Final Shop (Event / Transition)"), ToolTip("Splits on leaving Sly's shop after having bough Sprintmaster and Vessel Frag 8")]
         SlyShopFinished,
         [Description("Can Overcharm (Event)"), ToolTip("Splits when overcharming is enabled")]
         CanOvercharm,

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -12,8 +12,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
 [assembly: Guid("b3294e28-2bd4-4e39-92fa-e04a620c7e77")]
-[assembly: AssemblyVersion("3.1.0.0")]
-[assembly: AssemblyFileVersion("3.1.0.0")]
+[assembly: AssemblyVersion("3.1.1.0")]
+[assembly: AssemblyFileVersion("3.1.1.0")]
 #if !Info
 [assembly: ComponentFactory(typeof(HollowKnightFactory))]
 #endif


### PR DESCRIPTION
didn't add the .dll to this pr, no reason to since other edits to be made before upstream